### PR TITLE
fix darktheme colors for code inlined in lists

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -862,7 +862,7 @@ table>tbody>tr:nth-of-type(even) {
   color: #fff;
 }
 
-.dark p > code {
+.dark p > code, .dark li > code {
   background-color: #434B50;
   border-radius: 0px;
   color: #fff;


### PR DESCRIPTION
Without this, code inline in tables looks awful, like this:
![red on pink on charcoal](http://img.mduo13.com/screenshot-ilp_apidoc_list_code_colors.png)
