### PR TITLE
- Added a missed display of the type (GET, POST) of the query

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -159,7 +159,10 @@ td > p {
 
 .label-optional {
   float: right;
-  color: #606060;
+  color: #ff0076;
+  border: 1px solid;
+  font-weight: 500;
+  font-family: 'Source Sans Pro', sans-serif;
 }
 
 .open-left {
@@ -626,6 +629,8 @@ ul.nav-tabs {
 
 /*Custom*/
 
+
+
 button#version,
 .version {
   display: none;
@@ -971,4 +976,39 @@ table>tbody>tr:nth-of-type(even) {
 
 .dark .label-optional {
   color: #CCC;
+}
+
+/* ------------------------------------------------------------------------------------------
+ * Fix & usability
+ * ------------------------------------------------------------------------------------------ */
+.type {
+  font-family: "Source Sans Pro", sans-serif;
+  font-weight: 600;
+  font-size: 15px;
+  display: inline-block;
+  margin: 10px 0 0px 0;
+  padding: 4px 14px;
+  text-transform: uppercase;
+  background-color: #3387CC;
+  color: #ffffff;
+}
+
+.type__get {
+  background-color: green;
+}
+
+.type__put {
+  background-color: #e5c500;
+}
+
+.type__post {
+  background-color: #4070ec;
+}
+
+.type__delete {
+  background-color: #ed0039;
+}
+
+pre .lit {
+  color: #00e2ff !important;
 }

--- a/index.html
+++ b/index.html
@@ -156,6 +156,8 @@
       <p>{{{nl2br article.description}}}</p>
     {{/if}}
 
+    <span class="type type__{{toLowerCase article.type}}">{{toLowerCase article.type}}</span>
+
     <pre class="prettyprint language-html" data-type="{{toLowerCase article.type}}"><code>{{article.url}}</code></pre>
 
     {{#if article.permission}}


### PR DESCRIPTION
- Added a missed display of the type (GET, POST) of the query in the view template;
- Few colors have been fixed for displaying numbers. At the request of our application developers. A more noticeable type of integrus in the response body;